### PR TITLE
"easy" interface for creating struct/union/array def

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,101 @@ C data types for FFI
 
 # SYNOPSIS
 
+In your C:
+
+```
+#include <stdint.h>
+
+typedef struct {
+  uint8_t red;
+  uint8_t green;
+  uint8_t blue;
+} color_value_t;
+
+typedef struct {
+  char name[22];
+  color_value_t value;
+} named_color_t;
+
+typedef named_color_t array_named_color_t[4];
+
+typedef union {
+  uint8_t  u8;
+  uint16_t u16;
+  uint32_t u32;
+  uint64_t u64;
+} anyint_t;
+```
+
+In your Perl:
+
+```perl
+package ColorValue {
+  use FFI::C
+    name => 'color_value_t',
+    struct => [
+      red => 'uint8',
+      green => 'uint8',
+      blue  => 'uint8',
+    ];
+}
+
+package NamedColor {
+  use FFI::C
+    name => 'named_color_t',
+    struct => [
+      name => 'string(22)',
+      value => 'color_value_t',
+    ];
+}
+
+package ArrayNamedColor {
+  use FFI::C
+    name => 'array_named_color_t',
+    array => [ 'array_named_color_t', 4 ];
+}
+
+my $array = ArrayNamedColor->new([
+  { name => "red",    value => { red => 255   } },
+  { name => "green",  value => { green => 255 } },
+  { name => "blue",   value => { blue => 255  } },
+  { name => "purple", value => { red => 255,
+                                 blue => 255  } },
+]);
+
+# dim each color by 1/2
+foreach my $color (@$array)
+{
+  $color->value->red  ( $color->value->red   / 2 );
+  $color->value->green( $color->value->green / 2 );
+  $color->value->blue ( $color->value->blue  / 2 );
+}
+
+# print out the colors
+foreach my $color (@$array)
+{
+  printf "%s [%02x %02x %02x]\n",
+    $color->name,
+    $color->value->red,
+    $color->value->green,
+    $color->value->blue;
+}
+
+package AnyInt {
+  use FFI::C
+    name => 'anyint_t',
+    union => [
+      u8  => 'uint8',
+      u16 => 'uint16',
+      u32 => 'uint32',
+      u64 => 'uint64',
+    ];
+}
+
+my $int = AnyInt->new({ u8 => 42 });
+print $int->u32;
+```
+
 # DESCRIPTION
 
 This distribution provides tools for building classes to interface for common C

--- a/lib/FFI/C.pm
+++ b/lib/FFI/C.pm
@@ -124,8 +124,7 @@ sub import
   my($def_class, $members, @extra) = map { defined $args{$_} ? ('FFI::C::' . ucfirst($_) . 'Def' => delete $args{$_} ) : () } qw( struct union array );
   Carp::croak("Specify only one of 'struct', 'union', or 'array'") if @extra;
 
-  $def_class ||= 'FFI::C::StructDef';
-  $members = [] unless defined $members;
+  return unless defined $def_class && defined $members;
 
   Carp::croak("Members must be an array ref")
     unless is_plain_arrayref $members;

--- a/lib/FFI/C.pm
+++ b/lib/FFI/C.pm
@@ -9,6 +9,97 @@ use 5.008001;
 
 =head1 SYNOPSIS
 
+In your C:
+
+ #include <stdint.h>
+ 
+ typedef struct {
+   uint8_t red;
+   uint8_t green;
+   uint8_t blue;
+ } color_value_t;
+ 
+ typedef struct {
+   char name[22];
+   color_value_t value;
+ } named_color_t;
+ 
+ typedef named_color_t array_named_color_t[4];
+ 
+ typedef union {
+   uint8_t  u8;
+   uint16_t u16;
+   uint32_t u32;
+   uint64_t u64;
+ } anyint_t;
+
+In your Perl:
+
+ package ColorValue {
+   use FFI::C
+     name => 'color_value_t',
+     struct => [
+       red => 'uint8',
+       green => 'uint8',
+       blue  => 'uint8',
+     ];
+ }
+ 
+ package NamedColor {
+   use FFI::C
+     name => 'named_color_t',
+     struct => [
+       name => 'string(22)',
+       value => 'color_value_t',
+     ];
+ }
+ 
+ package ArrayNamedColor {
+   use FFI::C
+     name => 'array_named_color_t',
+     array => [ 'array_named_color_t', 4 ];
+ }
+ 
+ my $array = ArrayNamedColor->new([
+   { name => "red",    value => { red => 255   } },
+   { name => "green",  value => { green => 255 } },
+   { name => "blue",   value => { blue => 255  } },
+   { name => "purple", value => { red => 255,
+                                  blue => 255  } },
+ ]);
+ 
+ # dim each color by 1/2
+ foreach my $color (@$array)
+ {
+   $color->value->red  ( $color->value->red   / 2 );
+   $color->value->green( $color->value->green / 2 );
+   $color->value->blue ( $color->value->blue  / 2 );
+ }
+ 
+ # print out the colors
+ foreach my $color (@$array)
+ {
+   printf "%s [%02x %02x %02x]\n",
+     $color->name,
+     $color->value->red,
+     $color->value->green,
+     $color->value->blue;
+ }
+ 
+ package AnyInt {
+   use FFI::C
+     name => 'anyint_t',
+     union => [
+       u8  => 'uint8',
+       u16 => 'uint16',
+       u32 => 'uint32',
+       u64 => 'uint64',
+     ];
+ }
+ 
+ my $int = AnyInt->new({ u8 => 42 });
+ print $int->u32;
+
 =head1 DESCRIPTION
 
 This distribution provides tools for building classes to interface for common C

--- a/maint/gh-macos
+++ b/maint/gh-macos
@@ -2,6 +2,7 @@
 
 set -ex
 
+cpanm --reinstall Alien::FFI
 cd $(mktemp -d)
 curl -L https://github.com/Perl5-FFI/FFI-Platypus/tarball/master | tar zxf -
 cd $(ls -1)

--- a/t/ffi_c.t
+++ b/t/ffi_c.t
@@ -40,4 +40,14 @@ is(
   'create generated union class'
 );
 
+{ package Null;
+  use FFI::C;
+}
+
+is(
+  Null->can('new'),
+  F(),
+  'null specification does not generate class',
+);
+
 done_testing;

--- a/t/ffi_c.t
+++ b/t/ffi_c.t
@@ -1,8 +1,43 @@
 use Test2::V0 -no_srand => 1;
 use FFI::C;
 
-ok 1;
+{ package Color;
+  use FFI::C
+    struct => [ red   => 'uint8',
+                green => 'uint8',
+                blue  => 'uint8' ];
+}
 
-diag 'todo';
+is(
+  Color->new({ blue => 10 }),
+  object {
+    call [ isa => 'Color' ] => T();
+    call red   => 0;
+    call green => 0;
+    call blue  => 10;
+    call [ red => 128 ] => 128;
+    call red => 128;
+  },
+  'create generated struct class',
+);
+
+{ package AnyInt;
+  use FFI::C
+    union => [ u8  => 'uint8',
+               u16 => 'uint16',
+               u32 => 'uint32',
+               u64 => 'uint64' ];
+}
+
+is(
+  AnyInt->new({u16 => 12}),
+  object {
+    call [ isa => 'AnyInt' ] => T();
+    call u16           => 12;
+    call [ u32 => 13 ] => 13;
+    call u32           => 13;
+  },
+  'create generated union class'
+);
 
 done_testing;


### PR DESCRIPTION
The synopsis is helpful for the direction that I am thinking of going in:

In C:

```c
#include <stdint.h>

typedef struct {
  uint8_t red;
  uint8_t green;
  uint8_t blue;
} color_value_t;

typedef struct {
  char name[22];
  color_value_t value;
} named_color_t;

typedef named_color_t array_named_color_t[4];

typedef union {
  uint8_t  u8;
  uint16_t u16;
  uint32_t u32;
  uint64_t u64;
} anyint_t;
```

In Perl:

```perl
package ColorValue {
  use FFI::C
    name => 'color_value_t',
    struct => [
      red => 'uint8',
      green => 'uint8',
      blue  => 'uint8',
    ];
}

package NamedColor {
  use FFI::C
    name => 'named_color_t',
    struct => [
      name => 'string(22)',
      value => 'color_value_t',
    ];
}

package ArrayNamedColor {
  use FFI::C
    name => 'array_named_color_t',
    array => [ 'array_named_color_t', 4 ];
}

my $array = ArrayNamedColor->new([
  { name => "red",    value => { red => 255   } },
  { name => "green",  value => { green => 255 } },
  { name => "blue",   value => { blue => 255  } },
  { name => "purple", value => { red => 255,
                                 blue => 255  } },
]);

# dim each color by 1/2
foreach my $color (@$array)
{
  $color->value->red  ( $color->value->red   / 2 );
  $color->value->green( $color->value->green / 2 );
  $color->value->blue ( $color->value->blue  / 2 );
}

# print out the colors
foreach my $color (@$array)
{
  printf "%s [%02x %02x %02x]\n",
    $color->name,
    $color->value->red,
    $color->value->green,
    $color->value->blue;
}

package AnyInt {
  use FFI::C
    name => 'anyint_t',
    union => [
      u8  => 'uint8',
      u16 => 'uint16',
      u32 => 'uint32',
      u64 => 'uint64',
    ];
}

my $int = AnyInt->new({ u8 => 42 });
print $int->u32;
```