### PR TITLE
Easy interface without "import"

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,12 @@ generated.  For an array you give it the member type and the element count.
 The element count is optional for variable length arrays, but keep in mind
 that when you create such an array you do need to provide a size.
 
+# CAVEATS
+
+[FFI::C](https://metacpan.org/pod/FFI::C) objects must be passed into C via [FFI::Platypus](https://metacpan.org/pod/FFI::Platypus) by pointers.
+So-called "pass-by-value" is not and will not be supported.  For
+"pass-by-value" record types, you should instead use [FFI::Platypus::Record](https://metacpan.org/pod/FFI::Platypus::Record).
+
 # SEE ALSO
 
 - [FFI::C](https://metacpan.org/pod/FFI::C)

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ package NamedColor {
 }
 
 package ArrayNamedColor {
-  FFI::C->array(['array_named_color_t' => 4]);
+  FFI::C->array(['named_color_t' => 4]);
 };
 
 my $array = ArrayNamedColor->new([

--- a/README.md
+++ b/README.md
@@ -4,11 +4,162 @@ C data types for FFI
 
 # SYNOPSIS
 
+In C:
+
+```
+#include <stdint.h>
+
+typedef struct {
+  uint8_t red;
+  uint8_t green;
+  uint8_t blue;
+} color_value_t;
+
+typedef struct {
+  char name[22];
+  color_value_t value;
+} named_color_t;
+
+typedef named_color_t array_named_color_t[4];
+
+typedef union {
+  uint8_t  u8;
+  uint16_t u16;
+  uint32_t u32;
+  uint64_t u64;
+} anyint_t;
+```
+
+In Perl:
+
+```perl
+use FFI::C;
+
+package ColorValue {
+  FFI::C->struct([
+    red   => 'uint8',
+    green => 'uint8',
+    blue  => 'uint8',
+  ]);
+}
+
+package NamedColor {
+  FFI::C->struct([
+    name  => 'string(22)',
+    value => 'color_value_t',
+  ]);
+}
+
+package ArrayNamedColor {
+  FFI::C->array(['array_named_color_t' => 4]);
+};
+
+my $array = ArrayNamedColor->new([
+  { name => "red",    value => { red   => 255 } },
+  { name => "green",  value => { green => 255 } },
+  { name => "blue",   value => { blue  => 255 } },
+  { name => "purple", value => { red   => 255,
+                                 blue  => 255 } },
+]);
+
+# dim each color by 1/2
+foreach my $color (@$array)
+{
+  $color->value->red  ( $color->value->red   / 2 );
+  $color->value->green( $color->value->green / 2 );
+  $color->value->blue ( $color->value->blue  / 2 );
+}
+
+# print out the colors
+foreach my $color (@$array)
+{
+  printf "%s [%02x %02x %02x]\n",
+    $color->name,
+    $color->value->red,
+    $color->value->green,
+    $color->value->blue;
+}
+
+package AnyInt {
+  FFI::C->union([
+    u8  => 'uint8',
+    u16 => 'uint16',
+    u32 => 'uint32',
+    u64 => 'uint64',
+  ]);
+}
+
+my $int = AnyInt->new({ u8 => 42 });
+print $int->u32;
+```
+
 # DESCRIPTION
 
 This distribution provides tools for building classes to interface for common C
 data types.  Arrays, `struct`, `union` and nested types based on those are
 supported.
+
+# METHODS
+
+## ffi
+
+## struct
+
+```
+FFI::C->struct($name, \@members);
+FFI::C->struct(\@members);
+```
+
+Generate a new [FFI::C::Struct](https://metacpan.org/pod/FFI::C::Struct) class with the given `@members` into
+the calling package.  (`@members` should be a list of name/type pairs).
+You may optionally give a `$name` which will be used for the
+[FFI::Platypus](https://metacpan.org/pod/FFI::Platypus) type name for the generated class.  If you do not
+specify a `$name`, a C style name will be generated from the last segment
+in the calling package name by converting to snake case and appending a
+`_t` to the end.
+
+As an example, given:
+
+```perl
+package MyLibrary::FooBar {
+  FFI::C->struct([
+    a => 'uint8',
+    b => 'float',
+  ]);
+};
+```
+
+You can use `MyLibrary::FooBar` via the file scoped [FFI::Platypus](https://metacpan.org/pod/FFI::Platypus) instance
+using the type `foo_bar_t`.
+
+```perl
+my $foobar = MyLibrary::FooBar->new({ a => 1, b => 3.14 });
+$ffi->function( my_library_func => [ 'foo_bar_t' ] => 'void' )->call($foobar);
+```
+
+## union
+
+```
+FFI::C->union($name, \@members);
+FFI::C->union(\@members);
+```
+
+This works exactly like the `struct` method above, except a
+[FFI::C::Union](https://metacpan.org/pod/FFI::C::Union) class is generated instead.
+
+## array
+
+```
+FFI::C->array($name, [$type, $count]);
+FFI::C->array($name, [$type]);
+FFI::C->array([$type, $count]);
+FFI::C->array([$type]);
+```
+
+This is similar to `struct` and `union` above, except [FFI::C::Array](https://metacpan.org/pod/FFI::C::Array) is
+generated.  For an array you give it the member type and the element count.
+The element count is optional for variable length arrays, but keep in mind
+that when you create such an array you do need to provide a size.
 
 # SEE ALSO
 

--- a/examples/synopsis/c.c
+++ b/examples/synopsis/c.c
@@ -1,0 +1,21 @@
+#include <stdint.h>
+
+typedef struct {
+  uint8_t red;
+  uint8_t green;
+  uint8_t blue;
+} color_value_t;
+
+typedef struct {
+  char name[22];
+  color_value_t value;
+} named_color_t;
+
+typedef named_color_t array_named_color_t[4];
+
+typedef union {
+  uint8_t  u8;
+  uint16_t u16;
+  uint32_t u32;
+  uint64_t u64;
+} anyint_t;

--- a/examples/synopsis/c.pl
+++ b/examples/synopsis/c.pl
@@ -1,0 +1,61 @@
+use strict;
+use warnings;
+use FFI::C;
+
+package ColorValue {
+  FFI::C->struct([
+    red   => 'uint8',
+    green => 'uint8',
+    blue  => 'uint8',
+  ]);
+}
+
+package NamedColor {
+  FFI::C->struct([
+    name  => 'string(22)',
+    value => 'color_value_t',
+  ]);
+}
+
+package ArrayNamedColor {
+  FFI::C->array(['named_color_t' => 4]);
+};
+
+my $array = ArrayNamedColor->new([
+  { name => "red",    value => { red   => 255 } },
+  { name => "green",  value => { green => 255 } },
+  { name => "blue",   value => { blue  => 255 } },
+  { name => "purple", value => { red   => 255,
+                                 blue  => 255 } },
+]);
+
+# dim each color by 1/2
+foreach my $color (@$array)
+{
+  $color->value->red  ( $color->value->red   / 2 );
+  $color->value->green( $color->value->green / 2 );
+  $color->value->blue ( $color->value->blue  / 2 );
+}
+
+# print out the colors
+foreach my $color (@$array)
+{
+  printf "%s [%02x %02x %02x]\n",
+    $color->name,
+    $color->value->red,
+    $color->value->green,
+    $color->value->blue;
+}
+
+package AnyInt {
+  FFI::C->union([
+    u8  => 'uint8',
+    u16 => 'uint16',
+    u32 => 'uint32',
+    u64 => 'uint64',
+  ]);
+}
+
+my $int = AnyInt->new({ u8 => 42 });
+print $int->u32;
+

--- a/examples/synopsis/util.pl
+++ b/examples/synopsis/util.pl
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use FFI::C::Util qw( init take );
+use FFI::C::Util qw( perl_to_c take );
 use FFI::C::StructDef;
 use FFI::Platypus::Memory qw( free );
 
@@ -13,7 +13,7 @@ my $def = FFI::C::StructDef->new(
 my $inst = $def->create;
 
 # initalize members
-init($inst, { x => 1, y => 2 });
+perl_to_c($inst, { x => 1, y => 2 });
 
 # take ownership
 my $ptr = take $inst;

--- a/examples/time.pl
+++ b/examples/time.pl
@@ -1,0 +1,50 @@
+use strict;
+use warnings;
+use FFI::Platypus 1.00;
+use FFI::C;
+
+my $ffi = FFI::Platypus->new(
+  api => 1,
+  lib => [undef],
+);
+FFI::C->ffi($ffi);
+
+package Unix::TimeStruct {
+
+  FFI::C->struct(tm => [
+    tm_sec    => 'int',
+    tm_min    => 'int',
+    tm_hour   => 'int',
+    tm_mday   => 'int',
+    tm_mon    => 'int',
+    tm_year   => 'int',
+    tm_wday   => 'int',
+    tm_yday   => 'int',
+    tm_isdst  => 'int',
+    tm_gmtoff => 'long',
+    _tm_zone  => 'opaque',
+  ]);
+
+  # For now 'string' is unsupported by FFI::C, but we
+  # can cast the time zone from an opaque pointer to
+  # string.
+  sub tm_zone {
+    my $self = shift;
+    $ffi->cast('opaque', 'string', $self->_tm_zone);
+  }
+
+  # attach the C localtime function
+  $ffi->attach( localtime => ['time_t*'] => 'tm', sub {
+    my($inner, $class, $time) = @_;
+    $time = time unless defined $time;
+    $inner->(\$time);
+  });
+}
+
+# now we can actually use our My::UnixTime class
+my $time = Unix::TimeStruct->localtime;
+printf "time is %d:%d:%d %s\n",
+  $time->tm_hour,
+  $time->tm_min,
+  $time->tm_sec,
+  $time->tm_zone;

--- a/lib/FFI/C.pm
+++ b/lib/FFI/C.pm
@@ -139,7 +139,7 @@ L<FFI::C::Union> class is generated instead.
 
 sub union
 {
-  require FFI::C::StructDef;
+  require FFI::C::UnionDef;
   $def_class = 'FFI::C::UnionDef';
   goto &_gen;
 }

--- a/lib/FFI/C.pm
+++ b/lib/FFI/C.pm
@@ -165,6 +165,12 @@ sub array
   goto &_gen;
 }
 
+=head1 CAVEATS
+
+L<FFI::C> objects must be passed into C via L<FFI::Platypus> by pointers.
+So-called "pass-by-value" is not and will not be supported.  For
+"pass-by-value" record types, you should instead use L<FFI::Platypus::Record>.
+
 =head1 SEE ALSO
 
 =over 4

--- a/lib/FFI/C.pm
+++ b/lib/FFI/C.pm
@@ -3,17 +3,167 @@ package FFI::C;
 use strict;
 use warnings;
 use 5.008001;
+use Carp ();
+use Ref::Util qw( is_ref is_plain_arrayref );
 
 # ABSTRACT: C data types for FFI
 # VERSION
 
 =head1 SYNOPSIS
 
+In C:
+
+# EXAMPLE: examples/synopsis/c.c
+
+In Perl:
+
+# EXAMPLE: examples/synopsis/c.pl
+
 =head1 DESCRIPTION
 
 This distribution provides tools for building classes to interface for common C
 data types.  Arrays, C<struct>, C<union> and nested types based on those are
 supported.
+
+=head1 METHODS
+
+=head2 ffi
+
+=cut
+
+our %ffi;
+
+sub _ffi_get
+{
+  my($filename) = @_;
+  $ffi{$filename} ||= do {
+    require FFI::Platypus;
+    FFI::Platypus->new( api => 1 );
+  };
+}
+
+sub ffi
+{
+  my($class, $new) = @_;
+  my(undef, $filename) = caller;
+
+  if($new)
+  {
+    Carp::croak("Already have an FFI::Platypus instance for $filename")
+      if defined $ffi{$filename};
+    return $ffi{$filename} = $new;
+  }
+
+  _ffi_get($filename);
+}
+
+=head2 struct
+
+ FFI::C->struct($name, \@members);
+ FFI::C->struct(\@members);
+
+Generate a new L<FFI::C::Struct> class with the given C<@members> into
+the calling package.  (C<@members> should be a list of name/type pairs).
+You may optionally give a C<$name> which will be used for the
+L<FFI::Platypus> type name for the generated class.  If you do not
+specify a C<$name>, a C style name will be generated from the last segment
+in the calling package name by converting to snake case and appending a
+C<_t> to the end.
+
+As an example, given:
+
+ package MyLibrary::FooBar {
+   FFI::C->struct([
+     a => 'uint8',
+     b => 'float',
+   ]);
+ };
+
+You can use C<MyLibrary::FooBar> via the file scoped L<FFI::Platypus> instance
+using the type C<foo_bar_t>.
+
+ my $foobar = MyLibrary::FooBar->new({ a => 1, b => 3.14 });
+ $ffi->function( my_library_func => [ 'foo_bar_t' ] => 'void' )->call($foobar);
+
+=cut
+
+our $def_class;
+sub _gen
+{
+  shift;
+  my($class, $filename) = caller;
+
+  my($name, $members);
+
+  if(@_ == 2 && !is_ref $_[0] && is_plain_arrayref $_[1])
+  {
+    ($name, $members) = @_;
+  }
+  elsif(@_ == 1 && is_plain_arrayref $_[0])
+  {
+    $name = lcfirst [split /::/, $class]->[-1];
+    $name =~ s/([A-Z]+)/'_' . lc($1)/ge;
+    $name .= "_t";
+    ($members) = @_;
+  }
+  else
+  {
+    my($method) = map { lc $_ } $def_class =~ /::([A-Za-z]+)Def$/;
+    Carp::croak("usage: FFI::C->$method([\$name], \\\@members)");
+  }
+
+  $def_class->new(
+    _ffi_get($filename),
+    name    => $name,
+    class   => $class,
+    members => $members,
+  );
+}
+
+sub struct
+{
+  require FFI::C::StructDef;
+  $def_class = 'FFI::C::StructDef';
+  goto &_gen;
+}
+
+=head2 union
+
+ FFI::C->union($name, \@members);
+ FFI::C->union(\@members);
+
+This works exactly like the C<struct> method above, except a
+L<FFI::C::Union> class is generated instead.
+
+=cut
+
+sub union
+{
+  require FFI::C::StructDef;
+  $def_class = 'FFI::C::UnionDef';
+  goto &_gen;
+}
+
+=head2 array
+
+ FFI::C->array($name, [$type, $count]);
+ FFI::C->array($name, [$type]);
+ FFI::C->array([$type, $count]);
+ FFI::C->array([$type]);
+
+This is similar to C<struct> and C<union> above, except L<FFI::C::Array> is
+generated.  For an array you give it the member type and the element count.
+The element count is optional for variable length arrays, but keep in mind
+that when you create such an array you do need to provide a size.
+
+=cut
+
+sub array
+{
+  require FFI::C::ArrayDef;
+  $def_class = 'FFI::C::ArrayDef';
+  goto &_gen;
+}
 
 =head1 SEE ALSO
 

--- a/lib/FFI/C/ArrayDef.pm
+++ b/lib/FFI/C/ArrayDef.pm
@@ -184,7 +184,7 @@ sub create
   {
     my $array = $self->SUPER::create(@_);
     $array->{count} = $count;
-    FFI::C::Util::init($array, $_[0]) if @_ == 1 && is_plain_arrayref $_[0];
+    FFI::C::Util::perl_to_c($array, $_[0]) if @_ == 1 && is_plain_arrayref $_[0];
     return $array;
   }
 

--- a/lib/FFI/C/ArrayDef.pm
+++ b/lib/FFI/C/ArrayDef.pm
@@ -7,7 +7,10 @@ use Ref::Util qw( is_blessed_ref is_ref is_plain_arrayref );
 use FFI::C::Array;
 use Sub::Install ();
 use Sub::Util ();
+use Scalar::Util qw( refaddr );
 use base qw( FFI::C::Def );
+
+our @CARP_NOT = qw( FFI::C );
 
 # ABSTRACT: Array data definition for FFI
 # VERSION
@@ -85,6 +88,8 @@ sub new
   {
     $member = $def;
   }
+
+  Carp::croak("Canot nest an array def inside of itself") if refaddr($member) == refaddr($self);
 
   Carp::croak("Illegal member")
     unless defined $member && is_blessed_ref($member) && $member->isa("FFI::C::Def");

--- a/lib/FFI/C/Def.pm
+++ b/lib/FFI/C/Def.pm
@@ -9,6 +9,8 @@ use Ref::Util qw( is_blessed_ref is_ref is_plain_hashref );
 use Sub::Install ();
 use Sub::Util ();
 
+our @CARP_NOT = qw( FFI::C );
+
 # ABSTRACT: Data definition for FFI
 # VERSION
 

--- a/lib/FFI/C/Def.pm
+++ b/lib/FFI/C/Def.pm
@@ -173,7 +173,7 @@ sub _generate_class
         owner => $owner,
         count => $count,
       }, $class;
-      FFI::C::Util::init($self, $_[0]) if @_ == 1 && is_ref $_[0];
+      FFI::C::Util::perl_to_c($self, $_[0]) if @_ == 1 && is_ref $_[0];
       $self;
     };
 
@@ -205,7 +205,7 @@ sub _generate_class
         ptr => $ptr,
         owner => $owner,
       }, $class;
-      FFI::C::Util::init($self, $_[0]) if @_ == 1 && is_ref $_[0];
+      FFI::C::Util::perl_to_c($self, $_[0]) if @_ == 1 && is_ref $_[0];
       $self;
     };
 
@@ -317,7 +317,7 @@ sub create
     owner => $owner,
   }, $class;
 
-  FFI::C::Util::init($inst, $_[0]) if @_ == 1 && is_plain_hashref $_[0];
+  FFI::C::Util::perl_to_c($inst, $_[0]) if @_ == 1 && is_plain_hashref $_[0];
 
   $inst;
 }

--- a/lib/FFI/C/Struct.pm
+++ b/lib/FFI/C/Struct.pm
@@ -46,7 +46,7 @@ sub AUTOLOAD
     if($member->{nest})
     {
       my $m = $member->{nest}->create($ptr,$self->{owner} || $self);
-      FFI::C::Util::init($m, $_[0]) if @_;
+      FFI::C::Util::perl_to_c($m, $_[0]) if @_;
       return $m;
     }
 

--- a/lib/FFI/C/StructDef.pm
+++ b/lib/FFI/C/StructDef.pm
@@ -138,11 +138,11 @@ sub new
         $member{size}   = $self->ffi->sizeof("$spec*");
         local $@;
         $member{align}  = eval { $self->ffi->alignof("$spec*") };
-        Carp::croak("FFI-C doesn't support $spec for struct or union members") if $@;
+        Carp::croak("undefined, or unsupported type: $spec") if $@;
       }
       else
       {
-        Carp::croak("FFI-C doesn't support $spec for struct or union members");
+        Carp::croak("undefined or unsupported type: $spec");
       }
 
       $self->{align} = $member{align} if $member{align} > $self->{align};

--- a/lib/FFI/C/StructDef.pm
+++ b/lib/FFI/C/StructDef.pm
@@ -14,7 +14,7 @@ use Sub::Util ();
 use constant _is_union => 0;
 use base qw( FFI::C::Def );
 
-our @CARP_NOT = qw( FFI::C::Util );
+our @CARP_NOT = qw( FFI::C::Util FFI::C );
 
 # ABSTRACT: Structured data definition for FFI
 # VERSION

--- a/lib/FFI/C/StructDef.pm
+++ b/lib/FFI/C/StructDef.pm
@@ -197,7 +197,7 @@ sub new
             my $self = shift;
             my $ptr = $self->{ptr} + $offset;
             my $m = $class->new($ptr,$self);
-            FFI::C::Util::init($m, $_[0]) if @_;
+            FFI::C::Util::perl_to_c($m, $_[0]) if @_;
             $m;
           };
         }

--- a/lib/FFI/C/StructDef.pm
+++ b/lib/FFI/C/StructDef.pm
@@ -11,6 +11,7 @@ use Ref::Util qw( is_blessed_ref is_plain_arrayref is_ref );
 use Carp ();
 use Sub::Install ();
 use Sub::Util ();
+use Scalar::Util qw( refaddr );
 use constant _is_union => 0;
 use base qw( FFI::C::Def );
 
@@ -107,6 +108,8 @@ sub new
       {
         if($spec->isa('FFI::C::Def'))
         {
+          Carp::croak("Canot nest a struct or union def inside of itself")
+            if refaddr($spec) == refaddr($self);
           $member{nest}  = $spec;
           $member{size}  = $spec->size;
           $member{align} = $spec->align;

--- a/lib/FFI/C/Util.pm
+++ b/lib/FFI/C/Util.pm
@@ -9,7 +9,7 @@ use Carp ();
 use Class::Inspector;
 use base qw( Exporter );
 
-our @EXPORT_OK = qw( init c_to_perl take owned );
+our @EXPORT_OK = qw( perl_to_c c_to_perl take owned );
 
 # ABSTRACT: Utility functions for dealing with structured C data
 # VERSION
@@ -25,23 +25,23 @@ the various def instances provided by L<FFI::C>
 
 =head1 FUNCTIONS
 
-=head2 init
+=head2 perl_to_c
 
- init $instance, \%values;  # for Struct/Union
- init $instance, \@values;  # for Array
+ perl_to_c $instance, \%values;  # for Struct/Union
+ perl_to_c $instance, \@values;  # for Array
 
 This function initializes the members of an instance.
 
 =cut
 
-sub init ($$)
+sub perl_to_c ($$)
 {
   my($inst, $values) = @_;
   if(is_blessed_ref $inst && $inst->isa('FFI::C::Array'))
   {
     Carp::croak("Tried to initalize a @{[ ref $inst ]} with something other than an array reference")
       unless is_plain_arrayref $values;
-    &init($inst->get($_), $values->[$_]) for 0..$#$values;
+    &perl_to_c($inst->get($_), $values->[$_]) for 0..$#$values;
   }
   elsif(is_blessed_ref $inst)
   {

--- a/t/00_diag.t
+++ b/t/00_diag.t
@@ -10,6 +10,7 @@ my %modules;
 my $post_diag;
 
 $modules{$_} = $_ for qw(
+  Capture::Tiny
   Class::Inspector
   ExtUtils::MakeMaker
   FFI::Platypus

--- a/t/ffi_c.t
+++ b/t/ffi_c.t
@@ -27,20 +27,25 @@ is(
   'FFI::C->ffi can call get as many times as we like',
 );
 
-{
-  my($out, $ret) = capture_merged {
-    require './examples/synopsis/c.pl';
-  };
-  is $ret, T(), 'example compiles';
-  note $out;
-}
+subtest 'example' => sub {
 
-my $array = ArrayNamedColor->new([
-  { name => "red",    value => { red   => 255 } },
-  { name => "green",  value => { green => 255 } },
-  { name => "blue",   value => { blue  => 255 } },
-  { name => "purple", value => { red   => 255,
-                                 blue  => 255 } },
-]);
+  skip_all 'test requires Perl 5.14 or better' unless $] >= 5.014;
+
+  {
+    my($out, $ret) = capture_merged {
+        require './examples/synopsis/c.pl';
+    };
+    is $ret, T(), 'example compiles';
+    note $out;
+  }
+
+  my $array = ArrayNamedColor->new([
+    { name => "red",    value => { red   => 255 } },
+    { name => "green",  value => { green => 255 } },
+    { name => "blue",   value => { blue  => 255 } },
+    { name => "purple", value => { red   => 255,
+                                   blue  => 255 } },
+  ]);
+};
 
 done_testing;

--- a/t/ffi_c.t
+++ b/t/ffi_c.t
@@ -1,6 +1,7 @@
 use Test2::V0 -no_srand => 1;
 use FFI::C;
 use FFI::Platypus;
+use Capture::Tiny qw( capture_merged );
 
 my $ffi = FFI::Platypus->new( api => 1 );
 
@@ -25,5 +26,13 @@ is(
   },
   'FFI::C->ffi can call get as many times as we like',
 );
+
+{
+  my($out, $ret) = capture_merged {
+    require './examples/synopsis/c.pl';
+  };
+  is $ret, T(), 'example compiles';
+  note $out;
+}
 
 done_testing;

--- a/t/ffi_c.t
+++ b/t/ffi_c.t
@@ -1,8 +1,29 @@
 use Test2::V0 -no_srand => 1;
 use FFI::C;
+use FFI::Platypus;
 
-ok 1;
+my $ffi = FFI::Platypus->new( api => 1 );
 
-diag 'todo';
+is(
+  FFI::C->ffi($ffi),
+  object {
+    call [ isa => 'FFI::Platypus' ] => T();
+  },
+  'FFI::C->ffi first set ok',
+);
+
+is(
+  dies { FFI::C->ffi($ffi) },
+  match qr/Already have an FFI::Platypus instance for/,
+  'FFI::C->ffi second call dies',
+);
+
+is(
+  FFI::C->ffi,
+  object {
+    call [ isa => 'FFI::Platypus' ] => T();
+  },
+  'FFI::C->ffi can call get as many times as we like',
+);
 
 done_testing;

--- a/t/ffi_c.t
+++ b/t/ffi_c.t
@@ -35,4 +35,12 @@ is(
   note $out;
 }
 
+my $array = ArrayNamedColor->new([
+  { name => "red",    value => { red   => 255 } },
+  { name => "green",  value => { green => 255 } },
+  { name => "blue",   value => { blue  => 255 } },
+  { name => "purple", value => { red   => 255,
+                                 blue  => 255 } },
+]);
+
 done_testing;

--- a/t/ffi_c_arraydef.t
+++ b/t/ffi_c_arraydef.t
@@ -205,4 +205,18 @@ is(
 
 }
 
+is(
+  dies {
+    my $ffi = FFI::Platypus->new( api => 1 );
+    FFI::C::ArrayDef->new(
+      name => 'self_nest_t',
+      members => [
+        'self_nest_t',
+      ],
+    );
+  },
+  match qr/Canot nest an array def inside of itself/,
+  'Canot nest an array def inside of itself',
+);
+
 done_testing;

--- a/t/ffi_c_structdef.t
+++ b/t/ffi_c_structdef.t
@@ -409,4 +409,18 @@ is(
 
 }
 
+is(
+  dies {
+    my $ffi = FFI::Platypus->new( api => 1 );
+    FFI::C::StructDef->new(
+      name => 'self_nest_t',
+      members => [
+        self => 'self_nest_t',
+      ],
+    );
+  },
+  match qr/Canot nest a struct or union def inside of itself/,
+  'Canot nest a struct or union def inside of itself',
+);
+
 done_testing;

--- a/t/ffi_c_util.t
+++ b/t/ffi_c_util.t
@@ -1,5 +1,5 @@
 use Test2::V0 -no_srand => 1;
-use FFI::C::Util qw( owned take init c_to_perl );
+use FFI::C::Util qw( owned take perl_to_c c_to_perl );
 use FFI::Platypus::Memory qw( free );
 use FFI::C::StructDef;
 use FFI::C::UnionDef;
@@ -46,9 +46,9 @@ subtest 'owned / take' => sub {
 
 };
 
-subtest 'init / c_to_perl' => sub {
+subtest 'perl_to_c / c_to_perl' => sub {
 
-  imported_ok 'init';
+  imported_ok 'perl_to_c';
   imported_ok 'c_to_perl';
 
   subtest 'generated classes' => sub {
@@ -83,7 +83,7 @@ subtest 'init / c_to_perl' => sub {
     );
 
     my $inst = $def->create;
-    init($inst, {
+    perl_to_c($inst, {
       x => 1,
       y => [
         { foo => 2, bar => 3, baz => 5.5 },
@@ -112,7 +112,7 @@ subtest 'init / c_to_perl' => sub {
           call u16 => 900;
         };
       },
-      'values initalized',
+      'value converted to c',
     );
 
     { no warnings 'once';
@@ -167,7 +167,7 @@ subtest 'init / c_to_perl' => sub {
     );
 
     my $inst = $def->create;
-    init($inst, {
+    perl_to_c($inst, {
       x => 1,
       y => [
         { foo => 2, bar => 3, baz => 5.5 },

--- a/xt/author/examples.t
+++ b/xt/author/examples.t
@@ -40,12 +40,17 @@ is(
 
 foreach my $example (map { bsd_glob "$_/*.pl" } @dirs)
 {
-  my $out = '';
-  my $err = '';
-  script_compiles $example;
-  script_runs $example, { stdout => \$out, stderr => \$err };
-  note "[out]\n$out" if $out ne '';
-  note "[err]\n$err" if $err ne '';
+  my $basename = path($example)->basename;
+  subtest $basename => sub {
+    skip_all 'test requires Perl 5.14 or better'
+      unless $basename ne 'c.pl' || $] >= 5.014;
+    my $out = '';
+    my $err = '';
+    script_compiles $example;
+    script_runs $example, { stdout => \$out, stderr => \$err };
+    note "[out]\n$out" if $out ne '';
+    note "[err]\n$err" if $err ne '';
+  };
 }
 
 done_testing;


### PR DESCRIPTION
This is an alternative to #14.  The previous version used `import` to create the generated methods at compile time.  This seemed like a good idea at first, because Perl subs are created at compile time too.  However, most `FFI::Platypus` usage happens at run-time, so on reflection it seems better to use class methods instead.

`FFI::C` keeps track of a file scoped `FFI::Platypus` instance that you can get using the `ffi` method (you can also set the instance, so long as you set it before it is used, this is important in case you want to use a different api level, etc).  It makes sense to scope the `FFI::Platypus` instance on the file rather than the package, because the most common use cases for creating structs/unions/arrays will be several different types in one .pm file.

The implementation is incomplete so the synopsis compiles, but does not run.